### PR TITLE
Fix GitHub Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,6 +26,8 @@ jobs:
           cache: yarn
       - id: configurepages
         uses: actions/configure-pages@v5
+        with:
+          static_site_generator: next
       - name: Restore cache
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Summary
- configure the GitHub Pages workflow to use `static_site_generator: next`

## Testing
- `yarn lint` *(fails: couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_68514930b5ac8329b3bbe701c82d0b8d