### PR TITLE
Improve SEO with canonical URLs

### DIFF
--- a/app/blog/[...slug]/page.tsx
+++ b/app/blog/[...slug]/page.tsx
@@ -49,9 +49,14 @@ export async function generateMetadata(props: {
     }
   })
 
+  const canonicalUrl = post.canonicalUrl || `${siteMetadata.siteUrl}/${post.path}/`
+
   return {
     title: post.title,
     description: post.summary,
+    alternates: {
+      canonical: canonicalUrl,
+    },
     openGraph: {
       title: post.title,
       description: post.summary,
@@ -60,7 +65,7 @@ export async function generateMetadata(props: {
       type: 'article',
       publishedTime: publishedAt,
       modifiedTime: modifiedAt,
-      url: './',
+      url: canonicalUrl,
       images: ogImages,
       authors: authors.length > 0 ? authors : [siteMetadata.author],
     },

--- a/data/blog/Automotive/ecu-remapping-fast.mdx
+++ b/data/blog/Automotive/ecu-remapping-fast.mdx
@@ -4,7 +4,7 @@ date: '2025-02-01'
 tags: ['Remapping', 'Tuning', 'Automotive']
 draft: false
 summary: A comprehensive guide to mastering ECU remapping quickly, covering the fundamentals of engine control units, recommended tools, and hands-on practice.
----
+canonicalUrl: https://infinitecurios.blog/blog/automotive/ecu-remapping-fast/
 
 # How to Learn ECU Remapping Fast: Strategies That Work
 

--- a/data/blog/Guides/best-ai-tools.mdx
+++ b/data/blog/Guides/best-ai-tools.mdx
@@ -4,6 +4,7 @@ date: '2025-02-15'
 tags: ['AI', 'Productivity', 'Tools']
 draft: false
 summary: A look at popular artificial intelligence applications that can help you work smarter and spark creativity today.
+canonicalUrl: https://infinitecurios.blog/blog/guides/best-ai-tools/
 ---
 
 # Best AI Tools You Can Use Right Now

--- a/data/blog/Guides/cloudflare-workers-complete-guide.mdx
+++ b/data/blog/Guides/cloudflare-workers-complete-guide.mdx
@@ -4,6 +4,7 @@ date: "2025-07-12"
 tags: ["Cloudflare", "Serverless", "Guide"]
 draft: false
 summary: A beginner-friendly walkthrough for building and deploying applications with Cloudflare Workers, including setup, core concepts, and practical examples.
+canonicalUrl: https://infinitecurios.blog/blog/guides/cloudflare-workers-complete-guide/
 ---
 
 # The Complete Guide to Cloudflare Workers (For Beginners)

--- a/data/blog/Guides/how-to-start-a-blog-2025.mdx
+++ b/data/blog/Guides/how-to-start-a-blog-2025.mdx
@@ -4,6 +4,7 @@ date: '2025-06-01'
 tags: ['Blogging', '2025', 'Guide']
 draft: false
 summary: A detailed walkthrough for launching your first blog in 2025 with modern tools and best practices.
+canonicalUrl: https://infinitecurios.blog/blog/guides/how-to-start-a-blog-2025/
 ---
 
 # How to Start a Blog in 2025

--- a/data/blog/Guides/make-money-blogging-2025.mdx
+++ b/data/blog/Guides/make-money-blogging-2025.mdx
@@ -4,6 +4,7 @@ date: '2025-03-28'
 tags: ['Blogging', 'Monetization', 'Marketing']
 draft: false
 summary: Discover practical and lesser-known strategies for monetizing your blog in 2025, drawing on both proven techniques and innovative new approaches.
+canonicalUrl: https://infinitecurios.blog/blog/guides/make-money-blogging-2025/
 ---
 
 # How to Make Money Blogging: Realistic Methods for 2025

--- a/data/blog/Guides/ultimate-guide-intermittent-fasting.mdx
+++ b/data/blog/Guides/ultimate-guide-intermittent-fasting.mdx
@@ -4,6 +4,7 @@ date: '2025-02-02'
 tags: ['Health', 'Nutrition', 'Fasting']
 draft: false
 summary: Learn how intermittent fasting works, its benefits, common fasting schedules, and practical tips for getting started safely.
+canonicalUrl: https://infinitecurios.blog/blog/guides/ultimate-guide-intermittent-fasting/
 ---
 
 # The Ultimate Guide to Intermittent Fasting for Beginners

--- a/data/blog/News/gpu-outage-crypto.mdx
+++ b/data/blog/News/gpu-outage-crypto.mdx
@@ -4,6 +4,7 @@ date: '2024-06-10'
 tags: ['Incident Report', 'DevOps', 'Infrastructure']
 draft: false
 summary: A routine OS update sidelined our GPU servers, sparking jokes about secret crypto mines. Here's how we got back online.
+canonicalUrl: https://infinitecurios.blog/blog/news/gpu-outage-crypto/
 ---
 
 # When Updates Attack: Our GPU Outage and the Great Crypto Fake-Out

--- a/data/blog/Personal Growth/embracing-minimalism.mdx
+++ b/data/blog/Personal Growth/embracing-minimalism.mdx
@@ -4,6 +4,7 @@ date: '2025-01-31'
 tags: ['Minimalism', 'Lifestyle', 'Wellness']
 draft: false
 summary: Learn practical tips for embracing a minimalist lifestyle, from decluttering your living space to prioritizing what really matters.
+canonicalUrl: https://infinitecurios.blog/blog/personal-growth/embracing-minimalism/
 ---
 
 # Embracing Minimalism: A Simple Guide to Living with Less

--- a/data/blog/Technology/amd-3d-vs-standard-processors.mdx
+++ b/data/blog/Technology/amd-3d-vs-standard-processors.mdx
@@ -4,6 +4,7 @@ date: '2025-06-30'
 tags: ['AMD', 'Ryzen', 'Gaming', 'Hardware']
 draft: false
 summary: Exploring the benefits of AMD's 3D V-Cache technology through processors like the Ryzen 7 5700 3D compared to their non-3D counterparts.
+canonicalUrl: https://infinitecurios.blog/blog/technology/amd-3d-vs-standard-processors/
 ---
 
 # AMD 3D V-Cache vs Standard Ryzen Processors

--- a/data/blog/github-actions-automate-blog.mdx
+++ b/data/blog/github-actions-automate-blog.mdx
@@ -4,6 +4,7 @@ date: '2025-07-01'
 tags: ['GitHub Actions', 'Blog Automation', '2025']
 draft: false
 summary: Explore ten powerful GitHub Actions that streamline publishing, improve quality, and keep your blog running smoothly.
+canonicalUrl: https://infinitecurios.blog/blog/github-actions-automate-blog/
 ---
 
 # Top 10 GitHub Actions to Automate Your Blog


### PR DESCRIPTION
## Summary
- add `canonicalUrl` to blog posts
- expose canonical metadata in blog post pages

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68692b7e5c6083299c94f705f3e7da26