### PR TITLE
Fix Google Analytics blocked by CSP

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,7 +7,7 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 // You might need to insert additional domains in script-src if you are using external services
 const ContentSecurityPolicy = `
   default-src 'self';
-  script-src 'self' 'unsafe-eval' 'unsafe-inline' giscus.app analytics.umami.is;
+  script-src 'self' 'unsafe-eval' 'unsafe-inline' giscus.app analytics.umami.is www.googletagmanager.com www.google-analytics.com pagead2.googlesyndication.com;
   style-src 'self' 'unsafe-inline';
   img-src * blob: data:;
   media-src *.s3.amazonaws.com;


### PR DESCRIPTION
## Summary
- allow GA and AdSense domains in `next.config.js` CSP settings

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Space Grotesk` font)*

------
https://chatgpt.com/codex/tasks/task_e_686b18e01f8083299abe53329051df55