### PR TITLE
Add social field to Contentlayer schemas

### DIFF
--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -107,6 +107,7 @@ export const Blog = defineDocumentType(() => ({
     images: { type: 'json' },
     authors: { type: 'list', of: { type: 'string' } },
     layout: { type: 'string' },
+    social: { type: 'json', required: false },
     bibliography: { type: 'string' },
     canonicalUrl: { type: 'string' },
   },
@@ -143,6 +144,7 @@ export const Authors = defineDocumentType(() => ({
     linkedin: { type: 'string' },
     github: { type: 'string' },
     layout: { type: 'string' },
+    social: { type: 'json', required: false },
   },
   computedFields,
 }))


### PR DESCRIPTION
## Summary
- include optional `social` JSON field for `Blog` and `Authors` document types
- regenerate Contentlayer

## Testing
- `npm run build` *(fails: Failed to fetch font from blocked domain)*

------
https://chatgpt.com/codex/tasks/task_e_686b1a86ac948329b78a412ed3de1ce6