### PR TITLE
Add basic AdSense ad unit

### DIFF
--- a/components/AdUnit.tsx
+++ b/components/AdUnit.tsx
@@ -1,0 +1,28 @@
+'use client'
+import { useEffect } from 'react'
+
+declare global {
+  interface Window {
+    adsbygoogle: unknown[]
+  }
+}
+
+export default function AdUnit() {
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.adsbygoogle = window.adsbygoogle || []
+      window.adsbygoogle.push({})
+    }
+  }, [])
+
+  return (
+    <ins
+      className="adsbygoogle"
+      style={{ display: 'block', textAlign: 'center' }}
+      data-ad-client="ca-pub-0103781347588761"
+      data-ad-slot="YOUR_SLOT_ID"
+      data-ad-format="auto"
+      data-full-width-responsive="true"
+    />
+  )
+}

--- a/layouts/PostLayout.tsx
+++ b/layouts/PostLayout.tsx
@@ -10,6 +10,7 @@ import Tag from '@/components/Tag'
 import siteMetadata from '@/data/siteMetadata'
 import ScrollTopAndComment from '@/components/ScrollTopAndComment'
 import SocialShare from '@/components/SocialShare'
+import AdUnit from '@/components/AdUnit'
 
 const editUrl = (path) => `${siteMetadata.siteRepo}/blob/main/data/${path}`
 const discussUrl = (path) =>
@@ -101,6 +102,7 @@ export default function PostLayout({ content, authorDetails, next, prev, childre
                 summary={content.social?.summary || title}
                 hashtags={content.social?.hashtags || ''}
               />
+              <AdUnit />
 
               <div className="pt-6 pb-6 text-sm text-gray-700 dark:text-gray-300">
                 <Link href={discussUrl(path).replace('mobile.twitter.com', 'x.com')} rel="nofollow">

--- a/layouts/PostSimple.tsx
+++ b/layouts/PostSimple.tsx
@@ -8,6 +8,7 @@ import PageTitle from '@/components/PageTitle'
 import SectionContainer from '@/components/SectionContainer'
 import siteMetadata from '@/data/siteMetadata'
 import ScrollTopAndComment from '@/components/ScrollTopAndComment'
+import AdUnit from '@/components/AdUnit'
 
 interface LayoutProps {
   content: CoreContent<Blog>
@@ -42,6 +43,7 @@ export default function PostLayout({ content, next, prev, children }: LayoutProp
           <div className="grid-rows-[auto_1fr] divide-y divide-gray-200 pb-8 xl:divide-y-0 dark:divide-gray-700">
             <div className="divide-y divide-gray-200 xl:col-span-3 xl:row-span-2 xl:pb-0 dark:divide-gray-700">
               <div className="prose dark:prose-invert max-w-none pt-10 pb-8">{children}</div>
+              <AdUnit />
             </div>
             {siteMetadata.comments && (
               <div className="pt-6 pb-6 text-center text-gray-700 dark:text-gray-300" id="comment">

--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,1 +1,2 @@
 google.com, pub-0103781347588761, DIRECT, f08c47fec0942fa0
+


### PR DESCRIPTION
## Summary
- add AdUnit React component for Google Ads
- insert AdUnit into PostLayout and PostSimple layouts
- ensure `ads.txt` ends with a newline

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Space Grotesk`)*

------
https://chatgpt.com/codex/tasks/task_e_686b2462a4788329ac0440262b0b9e56