### PR TITLE
Fix giscus config validation

### DIFF
--- a/components/Comments.tsx
+++ b/components/Comments.tsx
@@ -7,9 +7,18 @@ import siteMetadata from '@/data/siteMetadata'
 export default function Comments({ slug }: { slug: string }) {
   const [loadComments, setLoadComments] = useState(false)
 
-  if (!siteMetadata.comments?.provider) {
+  const giscus = siteMetadata.comments?.giscusConfig
+  const isConfigured =
+    siteMetadata.comments?.provider === 'giscus' &&
+    giscus?.repo &&
+    giscus?.repositoryId &&
+    giscus?.category &&
+    giscus?.categoryId
+
+  if (!isConfigured) {
     return null
   }
+
   return (
     <>
       {loadComments ? (


### PR DESCRIPTION
## Summary
- verify that giscus environment variables exist before rendering comments

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686ed7f9b6548329998eff7554f9e004